### PR TITLE
Updated Readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Links
 
 * [Homepage](http://www.spigotmc.org/resources/chatcontrol.271)
 * [ChatControl's Wiki](https://github.com/kangarko/ChatControl/wiki/Frequently-asked-questions-or-issues)
-* Releases: in folder precompiled or on the homepage
+* Releases: in folder [recompiled](https://github.com/kangarko/ChatControl/tree/master/precompiled) or on the [releases tab](https://github.com/kangarko/ChatControl/releases)
 
 Dave Thomas, founder of OTI, godfather of the Eclipse strategy:
 


### PR DESCRIPTION
Added a link onto the Github release tab and then the recompiled folder.  Easier access for users on mobile (but who's adding a plugin from there phone?), as well with just makes more logical sense.