### PR TITLE
Minor changes to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,18 +5,6 @@ labels: []
 body:
 
 
-
-- type: checkboxes
-  id: updated-version
-  attributes:
-    label: Are you using the latest version of the plugin available?
-    description: Please make sure you use the latest version of the plugin before submitting an issue, otherwise your issue will be ignored.
-    options:
-      - label: The plugin is up-to-date!
-        required: true
-        
-        
-        
 - type: markdown
   attributes:
     value: |
@@ -27,7 +15,19 @@ body:
       **Correct title:** 1.19.1: Chat event loses its format
 
       _Don't put "Paper" or "Spigot" etc. in your title._
-      
+
+
+- type: dropdown
+  id: updated-version
+  attributes:
+    label: Are you using the latest version of the plugin available?
+    description: Please make sure you use the latest version of the plugin before submitting an issue, otherwise your issue will be ignored.
+    options:
+      - "Yes, the plugin is up-to-date!"
+  validations:
+    required: true
+
+
 - type: dropdown
   attributes:
     label: Are you using MySQL?

--- a/.github/ISSUE_TEMPLATE/bug_report_velocity.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_velocity.yml
@@ -16,7 +16,17 @@ body:
       **Correct title:** 1.19.1: Chat event loses its format
 
       _Don't put "Paper" or "Spigot" etc. in your title._
-     
+
+- type: dropdown
+  id: updated-version
+  attributes:
+    label: Are you using the latest version of the plugin available?
+    description: Please make sure you use the latest version of the plugin before submitting an issue, otherwise your issue will be ignored.
+    options:
+      - "Yes, the plugin is up-to-date!"
+  validations:
+    required: true
+
 - type: dropdown
   attributes:
     label: Are you using MySQL?


### PR DESCRIPTION
The changes are as follows:

Changed the "Are you using the latest version of the plugin available?" type from ``checkboxes`` to ``dropdown``.
This will prevent github from adding these "task" to issues unnecessary
![image](https://user-images.githubusercontent.com/48093184/183964671-539a46a2-72a2-41c3-a893-86e5be097a7d.png)

Added the question "Are you using the latest version of the plugin available?" to ``bug_report_velocity.yml``
