### PR TITLE
New Functionality: chat with your allied factions

### DIFF
--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/api/Party.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/api/Party.java
@@ -36,6 +36,13 @@ public abstract class Party {
 		};
 	};
 
+	public static final Party FACTION_ALLY = new Party("factions-ally") {
+		@Override
+		public boolean isInParty(Player receiver, Player sender) {
+			return HookManager.getOnlineFactionPlayers(sender).contains(receiver) || HookManager.getAlliedFactionPlayers(sender).contains(receiver);
+		}
+	};
+
 	/**
 	 * Chat for PlotSquared - only shown to players inside the plot.
 	 */

--- a/chatcontrol-bukkit/src/main/resources/settings.yml
+++ b/chatcontrol-bukkit/src/main/resources/settings.yml
@@ -113,7 +113,7 @@ Channels:
   # 
   # - Party: Makes the channel players only reach other players in the same party. This can work
   #          together with Range, but does not require that option. 
-  #          Available values: factions-faction, plotsquared-plot, towny-town, towny-nation,
+  #          Available values: factions-faction, factions-ally, plotsquared-plot, towny-town, towny-nation,
   #          mcmmo-party, towny-ally, lands-land, bentobox-island-visitor, bentobox-island-coop,
   #          bentobox-island-trusted, bentobox-island-member, bentobox-island-subowner
   #          bentobox-island-owner, bentobox-island-mod and bentobox-island-admin


### PR DESCRIPTION
Creates the Party rule that uses Hook methods to deal with faction alliance channels.
Also adds 'factions-ally' to possible `Party` options in `settings.yml`