### PR TITLE
Fix: null IUser when changing nick via EssentialsX (console) (Issue #3198)

### DIFF
--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/listener/ThirdPartiesListener.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/listener/ThirdPartiesListener.java
@@ -376,7 +376,7 @@ final class EssentialsListener implements Listener {
 	 */
 	@EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
 	public void onNickChange(final NickChangeEvent event) {
-		final IUser player = event.getAffected();
+		final IUser player = event.getController();
 		final String newNick = event.getValue();
 
 		if (Settings.Tag.BACKWARD_COMPATIBLE) {


### PR DESCRIPTION
For some reason, the affected player is actually the sender of the command. If it is console, affected player is null. Controller is the actual target of the command.

Issue #3198

[EssentialsX/Commandnick](https://github.com/EssentialsX/Essentials/blob/2.x/Essentials/src/main/java/com/earth2me/essentials/commands/Commandnick.java#L110)