### PR TITLE
Feature: channels now support all faction relations: ally, truce and enemy (Issue #3192)

### DIFF
--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/api/Party.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/api/Party.java
@@ -36,10 +36,33 @@ public abstract class Party {
 		};
 	};
 
+	/**
+	 * This is a channel shown only to players in the Factions allied to the sender's.
+	 */
 	public static final Party FACTION_ALLY = new Party("factions-ally") {
 		@Override
 		public boolean isInParty(Player receiver, Player sender) {
-			return HookManager.getOnlineFactionPlayers(sender).contains(receiver) || HookManager.getAlliedFactionPlayers(sender).contains(receiver);
+			return HookManager.getOnlineFactionPlayers(sender).contains(receiver) || HookManager.getRelatedFactionPlayers(sender, "ALLY").contains(receiver);
+		}
+	};
+
+	/**
+	 * This is a channel shown only to players in the Factions enemy to the sender's.
+	 */
+	public static final Party FACTION_ENEMY = new Party("factions-enemy") {
+		@Override
+		public boolean isInParty(Player receiver, Player sender) {
+			return HookManager.getOnlineFactionPlayers(sender).contains(receiver) || HookManager.getRelatedFactionPlayers(sender, "ENEMY").contains(receiver);
+		}
+	};
+
+	/**
+	 * This is a channel shown only to players in the Factions in truce with the sender's.
+	 */
+	public static final Party FACTION_TRUCE = new Party("factions-truce") {
+		@Override
+		public boolean isInParty(Player receiver, Player sender) {
+			return HookManager.getOnlineFactionPlayers(sender).contains(receiver) || HookManager.getRelatedFactionPlayers(sender, "TRUCE").contains(receiver);
 		}
 	};
 

--- a/chatcontrol-bukkit/src/main/resources/settings.yml
+++ b/chatcontrol-bukkit/src/main/resources/settings.yml
@@ -113,10 +113,10 @@ Channels:
   # 
   # - Party: Makes the channel players only reach other players in the same party. This can work
   #          together with Range, but does not require that option. 
-  #          Available values: factions-faction, factions-ally, plotsquared-plot, towny-town, towny-nation,
-  #          mcmmo-party, towny-ally, lands-land, bentobox-island-visitor, bentobox-island-coop,
-  #          bentobox-island-trusted, bentobox-island-member, bentobox-island-subowner
-  #          bentobox-island-owner, bentobox-island-mod and bentobox-island-admin
+  #          Available values: factions-faction, factions-ally, factions-enemy, factions-truce,
+  #          plotsquared-plot, towny-town, towny-nation, mcmmo-party, towny-ally, lands-land,
+  #          bentobox-island-visitor, bentobox-island-coop, bentobox-island-trusted, bentobox-island-member,
+  #          bentobox-island-subowner, bentobox-island-owner, bentobox-island-mod and bentobox-island-admin
   #          [WARNING] The Party option does not work over proxy!
   #
   # - Message_Delay: This overrides Anti_Spam.Chat.Delay so you can chat chat delay per channel.


### PR DESCRIPTION
This idea came from Issue #3192

Tested with 3 different Faction plugins: FactionsUUID and 2 other Massive-based ones.