### PR TITLE
Fix: gradient mini tags unexpected gradient behavior (Issue #3205)

### DIFF
--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/model/Format.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/model/Format.java
@@ -509,7 +509,9 @@ public final class Format extends YamlConfig {
 					final String text = message.substring(to + 1, end);
 
 					parts.add(beforeGradient + gradient + variables.replaceLegacy(text));
-					start = end + "</gradient>".length();
+
+					// Commented due to causing issues with gradients
+					start = end/* + "</gradient>".length()*/;
 				}
 
 				parts.add(message.substring(start));


### PR DESCRIPTION
The commented code was removing the closing `</gradient>` tags from the messages. So, the considered text for the gradient was actually the full text, causing it not to display correctly.