### PR TITLE
Fix: duplicated proxy messages (Issue #3203)

### DIFF
--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/listener/ChatControlProxyListenerBukkit.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/listener/ChatControlProxyListenerBukkit.java
@@ -104,6 +104,11 @@ public final class ChatControlProxyListenerBukkit extends org.mineacademy.fo.pro
 			Debugger.debug("proxy", "Received proxy packet " + this.packet + " from server " + this.server);
 
 		if (this.packet == ChatControlProxyMessage.CHANNEL) {
+
+			// Avoids processing proxy messages in the same server it was sent from, to avoid duplicate messages and unnecessary proxy prefix
+			if (input.getServerName().equalsIgnoreCase(Platform.getCustomServerName()))
+				return;
+
 			final String channelName = input.readString();
 			final String senderName = input.readString();
 			final UUID senderUUID = input.readUUID();


### PR DESCRIPTION
Quite simpler solution: does not process the proxy message in the same server as it was sent from. It works fine because the message is sent to the audience in the origin server before the proxy packet is sent.

This results in:

Origin server (lobby), processed as local message:
`[global] Player: message`

Other servers, processed as proxy message:
`[lobby] [global] Player: message`

Tested extensively, quick example of it working below:
![image](https://github.com/user-attachments/assets/97b3d328-dbbd-43fa-9742-1b7c96205072)
