### PR TITLE
Feature: add network tab completion permission and configuration (Issue #

### DIFF
--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/command/CommandTell.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/command/CommandTell.java
@@ -105,6 +105,6 @@ public final class CommandTell extends ChatControlCommand {
 	 */
 	@Override
 	protected List<String> tabComplete() {
-		return this.args.length == 1 ? this.completeLastWordPlayerNames() : NO_COMPLETE;
+		return this.args.length == 1 ? this.completeLastWordPlayerNames(Settings.PrivateMessages.ALLOW_CROSS_SERVER_TAB_COMPLETE) : NO_COMPLETE;
 	}
 }

--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/command/chatcontrol/ChatControlCommands.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/command/chatcontrol/ChatControlCommands.java
@@ -138,6 +138,10 @@ public final class ChatControlCommands extends SimpleCommandGroup {
 			return CommonCore.tabComplete(this.getLastArg(), Players.getPlayerNamesForTabComplete(this.getSender()));
 		}
 
+		public final List<String> completeLastWordPlayerNames(boolean includeNetwork) {
+			return CommonCore.tabComplete(this.getLastArg(), Players.getPlayerNamesForTabComplete(this.getSender(), !includeNetwork));
+		}
+
 		/**
 		 * @see org.mineacademy.fo.command.SimpleCommand#findPlayerInternal(java.lang.String)
 		 */

--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/model/Players.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/model/Players.java
@@ -241,11 +241,15 @@ public final class Players {
 	 * of their names or nicknames according to Tab_Complete.Use_Nicknames setting.
 	 * Vanished players are included only if receiver has bypass reach permission.
 	 *
+	 * includeNetwork parameter is hardcoded to true in the compilePlayers method
+	 * because this was the default behavior before this parameter was added.
+	 * This means this function will return players from all network.
+	 *
 	 * @param includeVanished
 	 * @return
 	 */
 	public static Set<String> getPlayerNamesForTabComplete(final boolean includeVanished) {
-		return compilesPlayers(includeVanished, Proxy.ENABLE_NETWORK_TAB_COMPLETING, Settings.TabComplete.USE_NICKNAMES);
+		return compilesPlayers(includeVanished, true, Settings.TabComplete.USE_NICKNAMES);
 	}
 
 	/**
@@ -256,11 +260,20 @@ public final class Players {
 	 * @param requester
 	 * @return
 	 */
-	public static Set<String> getPlayerNamesForTabComplete(@NonNull final CommandSender requester) {
+	public static Set<String> getPlayerNamesForTabComplete(@NonNull final CommandSender requester, final boolean ignoreNetwork) {
 		final boolean includeVanished = requester.hasPermission(Permissions.Bypass.VANISH),
-				includeNetwork = Proxy.ENABLE_NETWORK_TAB_COMPLETING || requester.hasPermission(Permissions.Bypass.NETWORK_TAB_COMPLETING);
+				includeNetwork = !ignoreNetwork || requester.hasPermission(Permissions.Bypass.NETWORK_TAB_COMPLETING);
 
 		return compilesPlayers(includeVanished, includeNetwork, Settings.TabComplete.USE_NICKNAMES);
+	}
+
+	/*
+	 * ignoreNetwork parameter is hardcoded to false in the getPlayerNamesForTabComplete
+	 * method because this was the default behavior before this parameter was added.
+	 * This means this function will return players from all network.
+	 */
+	public static Set<String> getPlayerNamesForTabComplete(@NonNull final CommandSender requester) {
+		return getPlayerNamesForTabComplete(requester, false);
 	}
 
 	/*

--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/model/Players.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/model/Players.java
@@ -245,7 +245,7 @@ public final class Players {
 	 * @return
 	 */
 	public static Set<String> getPlayerNamesForTabComplete(final boolean includeVanished) {
-		return compilesPlayers(includeVanished, Settings.TabComplete.USE_NICKNAMES);
+		return compilesPlayers(includeVanished, Proxy.ENABLE_NETWORK_TAB_COMPLETING, Settings.TabComplete.USE_NICKNAMES);
 	}
 
 	/**
@@ -257,22 +257,23 @@ public final class Players {
 	 * @return
 	 */
 	public static Set<String> getPlayerNamesForTabComplete(@NonNull final CommandSender requester) {
-		final boolean includeVanished = requester.hasPermission(Permissions.Bypass.VANISH);
+		final boolean includeVanished = requester.hasPermission(Permissions.Bypass.VANISH),
+				includeNetwork = Proxy.ENABLE_NETWORK_TAB_COMPLETING || requester.hasPermission(Permissions.Bypass.NETWORK_TAB_COMPLETING);
 
-		return compilesPlayers(includeVanished, Settings.TabComplete.USE_NICKNAMES);
+		return compilesPlayers(includeVanished, includeNetwork, Settings.TabComplete.USE_NICKNAMES);
 	}
 
 	/*
 	 * Compile a list of players
 	 */
-	private static Set<String> compilesPlayers(final boolean includeVanished, final boolean preferNicknames) {
+	private static Set<String> compilesPlayers(final boolean includeVanished, final boolean includeNetwork, final boolean preferNicknames) {
 		final Set<String> players = (preferNicknames ? playerNicknames : playerNames).getOrDefault(includeVanished, new TreeSet<>());
 
 		if (!players.isEmpty())
 			return players;
 
 		// Add players from the network
-		if (Proxy.ENABLED)
+		if (Proxy.ENABLED && includeNetwork)
 			for (final SyncedCache cache : SyncedCache.getCaches())
 				if (includeVanished || !cache.isVanished())
 					players.add(preferNicknames ? cache.getNameOrNickColorless() : cache.getPlayerName());

--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/settings/Settings.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/settings/Settings.java
@@ -77,7 +77,6 @@ public final class Settings extends SimpleSettings {
 
 		public static Boolean ENABLED;
 		public static String PREFIX;
-		public static Boolean ENABLE_NETWORK_TAB_COMPLETING;
 
 		private static void init() {
 			// Handled in the main init() to ensure first priority
@@ -467,6 +466,7 @@ public final class Settings extends SimpleSettings {
 
 		public static Boolean ENABLED;
 		public static Boolean PROXY;
+		public static Boolean ALLOW_CROSS_SERVER_TAB_COMPLETE;
 		public static Boolean TOASTS;
 		public static SimpleSound SOUND;
 		public static Boolean AUTOMODE;
@@ -488,6 +488,7 @@ public final class Settings extends SimpleSettings {
 
 			ENABLED = getBoolean("Enabled");
 			PROXY = getBoolean("Proxy");
+			ALLOW_CROSS_SERVER_TAB_COMPLETE = getBoolean("Allow_Cross_Server_Tab_Complete");
 			TOASTS = getBoolean("Toasts");
 			SOUND = get("Sound", SimpleSound.class);
 			AUTOMODE = getBoolean("Auto_Mode");
@@ -1283,7 +1284,6 @@ public final class Settings extends SimpleSettings {
 
 		Proxy.ENABLED = proxyConfig.getBoolean("Enabled");
 		Proxy.PREFIX = proxyConfig.getString("Prefix");
-		Proxy.ENABLE_NETWORK_TAB_COMPLETING = proxyConfig.getBoolean("Enable_Network_Tab_Completion");
 
 		try {
 			Platform.setCustomServerName(proxyConfig.getString("Server_Name"));

--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/settings/Settings.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/settings/Settings.java
@@ -77,6 +77,7 @@ public final class Settings extends SimpleSettings {
 
 		public static Boolean ENABLED;
 		public static String PREFIX;
+		public static Boolean ENABLE_NETWORK_TAB_COMPLETING;
 
 		private static void init() {
 			// Handled in the main init() to ensure first priority
@@ -1282,6 +1283,7 @@ public final class Settings extends SimpleSettings {
 
 		Proxy.ENABLED = proxyConfig.getBoolean("Enabled");
 		Proxy.PREFIX = proxyConfig.getString("Prefix");
+		Proxy.ENABLE_NETWORK_TAB_COMPLETING = proxyConfig.getBoolean("Enable_Network_Tab_Completion");
 
 		try {
 			Platform.setCustomServerName(proxyConfig.getString("Server_Name"));

--- a/chatcontrol-bukkit/src/main/resources/proxy.yml
+++ b/chatcontrol-bukkit/src/main/resources/proxy.yml
@@ -17,10 +17,3 @@ Prefix: "<dark_gray>[<yellow>{server_name}<dark_gray>] <gray>"
 # **WARNING** If using proxy, this must match the server name you have in velocity.toml or 
 #             BungeeControl's config.yml, NOT your server alias in BungeeControl or VelocityControl.
 Server_Name: ''
-
-# Controls whether player username tab-completion includes players from the entire proxy network.
-#
-# If set to true, all players will be able to tab-complete usernames of players across all servers.
-# If set to false, only players with the 'chatcontrol.bypass.network.tabcomplete' permission
-# will see players from other servers in tab-completion. Others will only see players from their current server.
-Enable_Network_Tab_Completion: true

--- a/chatcontrol-bukkit/src/main/resources/proxy.yml
+++ b/chatcontrol-bukkit/src/main/resources/proxy.yml
@@ -18,6 +18,9 @@ Prefix: "<dark_gray>[<yellow>{server_name}<dark_gray>] <gray>"
 #             BungeeControl's config.yml, NOT your server alias in BungeeControl or VelocityControl.
 Server_Name: ''
 
-# Disable including players from other servers in tab completion
-# for senders who lack chatcontrol.bypass.network.tabcomplete permission?
+# Controls whether player username tab-completion includes players from the entire proxy network.
+#
+# If set to true, all players will be able to tab-complete usernames of players across all servers.
+# If set to false, only players with the 'chatcontrol.bypass.network.tabcomplete' permission
+# will see players from other servers in tab-completion. Others will only see players from their current server.
 Enable_Network_Tab_Completion: true

--- a/chatcontrol-bukkit/src/main/resources/proxy.yml
+++ b/chatcontrol-bukkit/src/main/resources/proxy.yml
@@ -17,3 +17,7 @@ Prefix: "<dark_gray>[<yellow>{server_name}<dark_gray>] <gray>"
 # **WARNING** If using proxy, this must match the server name you have in velocity.toml or 
 #             BungeeControl's config.yml, NOT your server alias in BungeeControl or VelocityControl.
 Server_Name: ''
+
+# Disable including players from other servers in tab completion
+# for senders who lack chatcontrol.bypass.network.tabcomplete permission?
+Enable_Network_Tab_Completion: true

--- a/chatcontrol-bukkit/src/main/resources/settings.yml
+++ b/chatcontrol-bukkit/src/main/resources/settings.yml
@@ -495,7 +495,14 @@ Private_Messages:
   
   # Should we send private messages to players on another server? Enable proxy in proxy.yml first.
   Proxy: true
-  
+
+  # Controls whether player username tab-completion includes players from the entire proxy network.
+  #
+  # If set to true, all players will be able to tab-complete usernames of players across all servers.
+  # If set to false, only players with the 'chatcontrol.bypass.network.tabcomplete' permission
+  # will see players from other servers in tab-completion. Others will only see players from their current server.
+  Allow_Cross_Server_Tab_Complete: true
+
   # Send message as an advancement? Requires Minecraft 1.12+. Imposes a performance penaulty.
   Toasts: false
   

--- a/chatcontrol-core/src/main/java/org/mineacademy/chatcontrol/model/Permissions.java
+++ b/chatcontrol-core/src/main/java/org/mineacademy/chatcontrol/model/Permissions.java
@@ -246,7 +246,7 @@ public final class Permissions {
 		@Permission("Prevent player actions from being spied upon. Append chat, command, private_message, mail, sígn, book or anvil at the end.")
 		public static final String SPY_TYPE = "chatcontrol.bypass.spy.";
 
-		@Permission("See all network players when tab completing even if Enable_Network_Tab_Completion is disabled.")
+		@Permission("Allows the user to see all players across the network when tab-completing private messages, even if cross-server tab completion is disabled in the config.")
 		public static final String NETWORK_TAB_COMPLETING = "chatcontrol.bypass.network.tabcomplete";
 	}
 

--- a/chatcontrol-core/src/main/java/org/mineacademy/chatcontrol/model/Permissions.java
+++ b/chatcontrol-core/src/main/java/org/mineacademy/chatcontrol/model/Permissions.java
@@ -245,6 +245,9 @@ public final class Permissions {
 
 		@Permission("Prevent player actions from being spied upon. Append chat, command, private_message, mail, sígn, book or anvil at the end.")
 		public static final String SPY_TYPE = "chatcontrol.bypass.spy.";
+
+		@Permission("See all network players when tab completing even if Enable_Network_Tab_Completion is disabled.")
+		public static final String NETWORK_TAB_COMPLETING = "chatcontrol.bypass.network.tabcomplete";
 	}
 
 	@PermissionGroup("Permissions for chat channels.")


### PR DESCRIPTION
Issue #3228

The user wanted to keep `Proxy: true` under `Private_Messages` but limit tab-completion so that regular players could only see others on the same server - not the entire network.

To address this, I introduced a new boolean setting under the `Private_Message` section:
`Allow_Cross_Server_Tab_Complete`, which is `true` by default.

When disabled, players will only be able to tab-complete names of players on the same server. A new permission node `chatcontrol.bypass.network.tabcomplete` allows staff or privileged users to continue seeing all network players in tab-completion, regardless of this setting.