### PR TITLE
Fix: prevent empty formats from being sent to receivers (Issue #3195)

### DIFF
--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/model/Channel.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/model/Channel.java
@@ -627,14 +627,12 @@ public final class Channel extends YamlConfig implements ConfigStringSerializabl
 					receiverAudience.sendMessage(formattedComponent);
 
 					atLeastOneSuccessfulSent = true;
-				} else {
+				} else if(!formattedComponent.isEmpty(receiverAudience)) {
 					final String replacedMini = HookManager.replaceRelationPlaceholders(sender.getPlayer(), receiver, formattedComponent.toMini(receiverAudience));
 
-					if (!replacedMini.trim().isEmpty()) {
-						receiverAudience.sendMessage(SimpleComponent.fromMiniSection(replacedMini));
+					receiverAudience.sendMessage(SimpleComponent.fromMiniSection(replacedMini));
 
-						atLeastOneSuccessfulSent = true;
-					}
+					atLeastOneSuccessfulSent = true;
 				}
 			}
 


### PR DESCRIPTION
Issue #3195

After parsing and evaluating conditions or permissions, if the resulting format is empty, the message will be skipped and not delivered to the receiver.