### PR TITLE
Fix: improve offline player check to prevent cross-server PM inconsistencies (Issue #3230)

### DIFF
--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/command/CommandTell.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/command/CommandTell.java
@@ -95,7 +95,13 @@ public final class CommandTell extends ChatControlCommand {
 			return;
 		}
 
-		this.checkNotNull(syncedReceiverCache, Lang.component("command-tell-receiver-offline", "receiver_name", this.args[0]));
+		this.checkBoolean(
+				syncedReceiverCache != null // Original offline player check, reversed to match new verification method
+				// Prevents cross-server PMs when disabled. Previously, the message wasn't delivered,
+				// but the sender still saw it as if it was — this fixes that inconsistency.
+				&& (Settings.PrivateMessages.PROXY || syncedReceiverCache.getServerName().equals(syncedSenderCache.getServerName())),
+				Lang.component("command-tell-receiver-offline", "receiver_name", this.args[0])
+		);
 
 		PrivateMessage.send(wrapped, syncedReceiverCache, message);
 	}


### PR DESCRIPTION
Issue #3230 

Fixes an issue where private messages sent to players on other servers appeared to be sent even when cross-server PMs were disabled. The message was not delivered to the target, but the sender still saw it as if it was. This change ensures the sender no longer receives that misleading feedback when cross-server PMs are disabled.