### PR TITLE
Fix: improve ANNOUNCE_PARAM_PATTERN regex for better key:value matching (Issue #3249)

### DIFF
--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/command/chatcontrol/AnnounceSubCommand.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/command/chatcontrol/AnnounceSubCommand.java
@@ -31,7 +31,7 @@ public final class AnnounceSubCommand extends MainSubCommand {
 	/**
 	 * The pattern to match key:value pairs in the message
 	 */
-	private static final Pattern ANNOUNCE_PARAM_PATTERN = Pattern.compile("\\b[a-zA-Z]+:[a-zA-Z0-9_]+\\b(?!(?=[^<]*>))");
+	private static final Pattern ANNOUNCE_PARAM_PATTERN = Pattern.compile("\\b[a-zA-Z]+:[a-zA-Z0-9_]+\\b(?!(?:[^\"<]*(?:\"[^\"]*\"|<[^>]*>))*[^\"<]*>)");
 
 	public AnnounceSubCommand() {
 		super("announce/a/broadcast/bc");


### PR DESCRIPTION
(Issue #3249)

Old RegExp:

<img width="1212" height="442" alt="image" src="https://github.com/user-attachments/assets/4182dda6-98ce-4ae7-af4e-04d62cb4a260" />

New RegExp:

<img width="1223" height="437" alt="image" src="https://github.com/user-attachments/assets/2b4b6cad-a9c4-486b-a04c-1f2736a39c9c" />
