### PR TITLE
New: new rule operator 'ignore players' to ignore messages that match any player's online name (Issue #3324)

### DIFF
--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/operator/Rule.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/operator/Rule.java
@@ -306,6 +306,10 @@ public class Rule extends RuleOperator {
 		@Override
 		protected void filter(final RuleOperator rule) throws EventHandledException {
 
+			// Ignore if the message matches any player's online name and the rule is ignoring them
+			if (rule.isIgnorePlayers() && Platform.getOnlinePlayers().stream().anyMatch(player -> player.getName().equalsIgnoreCase(this.message)))
+				return;
+
 			// Set this to use later in variables
 			this.ruleOrGroupEvaluated = rule;
 

--- a/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/operator/RuleOperator.java
+++ b/chatcontrol-bukkit/src/main/java/org/mineacademy/chatcontrol/operator/RuleOperator.java
@@ -135,6 +135,11 @@ public abstract class RuleOperator extends Operator {
 	private final Set<String> ignoreRegions = new HashSet<>();
 
 	/**
+	 * Filter messages that match any player's online name?
+	 */
+	private boolean ignorePlayers = false;
+
+	/**
 	 * List of channels and their modes to ignore matching from
 	 */
 	private final Map<String, String> ignoreChannels = new HashMap<>();
@@ -266,6 +271,9 @@ public abstract class RuleOperator extends Operator {
 				this.ignoreChannels.put(channelName, mode);
 			}
 
+		else if ("ignore players".equalsIgnoreCase(param))
+			this.ignorePlayers = true;
+
 		else if ("then replace".equals(param))
 			this.replacements.addAll(theRestSplit);
 
@@ -315,6 +323,7 @@ public abstract class RuleOperator extends Operator {
 				"Ignore Worlds", this.ignoreWorlds,
 				"Ignore Regions", this.ignoreRegions,
 				"Ignore Channels", this.ignoreChannels,
+				"Ignore Players", this.ignorePlayers,
 				"Replacements", this.replacements,
 				"Rewrites", this.rewrites,
 				"World Rewrites", this.worldRewrites));


### PR DESCRIPTION
@kangarko 
I've added this since it was requested in #3324 and it made total sense to me, as well as it seemed straightforward to implement.

I wonder if it makes any sense to you and I'll wait on your feedback before I publis this.

Thanks a lot!